### PR TITLE
Replace usage of postgres 'id serial' with 'id integer primary key generated always as identity' to be compliant with postgres best practices and the SQL specification standard.

### DIFF
--- a/src/cigogne.gleam
+++ b/src/cigogne.gleam
@@ -20,7 +20,7 @@ fn migration_zero() -> types.Migration {
     "CreateMigrationsTable",
     [
       "CREATE TABLE IF NOT EXISTS _migrations(
-    id SERIAL PRIMARY KEY,
+    id INTEGER PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
     name VARCHAR(255) NOT NULL,
     createdAt TIMESTAMP WITHOUT TIME ZONE NOT NULL,
     appliedAt TIMESTAMP NOT NULL DEFAULT NOW()

--- a/test/cigogne/internal/fs_test.gleam
+++ b/test/cigogne/internal/fs_test.gleam
@@ -174,8 +174,8 @@ pub fn get_migrations_test() {
   second.name |> should.equal("Test2")
   second.queries_up
   |> should.equal([
-    "create table tags(id serial primary key, tag text not null);",
-    "alter table todos add column tag serial references tags(id);",
+    "create table tags(id INTEGER PRIMARY KEY GENERATED ALWAYS AS IDENTITY, tag text not null);",
+    "alter table todos add column tag integer references tags(id);",
   ])
   second.queries_down
   |> should.equal(["alter table todos drop column tag;", "drop table tags;"])
@@ -204,8 +204,8 @@ fn setup_and_teardown_migrations(test_cb: fn() -> Result(a, b)) {
       mig_2,
       "
   --- migration:up
-  create table tags(id serial primary key, tag text not null);
-  alter table todos add column tag serial references tags(id);
+  create table tags(id INTEGER PRIMARY KEY GENERATED ALWAYS AS IDENTITY, tag text not null);
+  alter table todos add column tag integer references tags(id);
   --- migration:down
   alter table todos drop column tag;
   drop table tags;


### PR DESCRIPTION
Hello. Thanks for this library. I wanted to contribute a little bit and noticed you create the migrations table with `id serial`. This is actually not the best practice anymore since serial is not part of the sql standard, and have replaced it with `integer primary key generated always as identity`. Here's a stack overflow link that shows some of the differences

https://stackoverflow.com/a/55300741

thanks