### PR TITLE
Upgrade Pog to v4

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -19,7 +19,7 @@ internal_modules = [
 [dependencies]
 gleam_stdlib = ">= 0.60.0 and < 1.0.0"
 argv = ">= 1.0.2 and < 2.0.0"
-pog = ">= 3.1.0 and < 4.0.0"
+pog = ">= 4.0.0 and < 5.0.0"
 envoy = ">= 1.0.2 and < 2.0.0"
 shellout = ">= 1.7.0 and < 2.0.0"
 globlin = ">= 2.0.3 and < 3.0.0"
@@ -27,6 +27,8 @@ globlin_fs = ">= 2.0.0 and < 3.0.0"
 simplifile = ">= 2.2.1 and < 3.0.0"
 gtempo = ">= 7.2.2 and < 8.0.0"
 gleam_crypto = ">= 1.5.1 and < 2.0.0"
+gleam_time = ">= 1.2.0 and < 2.0.0"
+gleam_erlang = ">= 1.2.0 and < 2.0.0"
 
 [dev-dependencies]
 gleeunit = ">= 1.6.0 and < 2.0.0"

--- a/gleam.toml
+++ b/gleam.toml
@@ -17,16 +17,16 @@ internal_modules = [
 ]
 
 [dependencies]
-gleam_stdlib = ">= 0.60.0 and < 2.0.0"
+gleam_stdlib = ">= 0.60.0 and < 1.0.0"
 argv = ">= 1.0.2 and < 2.0.0"
 pog = ">= 3.1.0 and < 4.0.0"
 envoy = ">= 1.0.2 and < 2.0.0"
-shellout = ">= 1.6.0 and < 2.0.0"
-globlin = ">= 2.0.2 and < 3.0.0"
+shellout = ">= 1.7.0 and < 2.0.0"
+globlin = ">= 2.0.3 and < 3.0.0"
 globlin_fs = ">= 2.0.0 and < 3.0.0"
-simplifile = ">= 2.2.0 and < 3.0.0"
-gtempo = ">= 7.2.0"
-gleam_crypto = ">= 1.5.0 and < 2.0.0"
+simplifile = ">= 2.2.1 and < 3.0.0"
+gtempo = ">= 7.2.2 and < 8.0.0"
+gleam_crypto = ">= 1.5.1 and < 2.0.0"
 
 [dev-dependencies]
-gleeunit = ">= 1.0.0 and < 2.0.0"
+gleeunit = ">= 1.6.0 and < 2.0.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -5,8 +5,11 @@ packages = [
   { name = "argv", version = "1.0.2", build_tools = ["gleam"], requirements = [], otp_app = "argv", source = "hex", outer_checksum = "BA1FF0929525DEBA1CE67256E5ADF77A7CDDFE729E3E3F57A5BDCAA031DED09D" },
   { name = "backoff", version = "1.1.6", build_tools = ["rebar3"], requirements = [], otp_app = "backoff", source = "hex", outer_checksum = "CF0CFFF8995FB20562F822E5CC47D8CCF664C5ECDC26A684CBE85C225F9D7C39" },
   { name = "envoy", version = "1.0.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "envoy", source = "hex", outer_checksum = "95FD059345AA982E89A0B6E2A3BF1CF43E17A7048DCD85B5B65D3B9E4E39D359" },
+  { name = "exception", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "exception", source = "hex", outer_checksum = "329D269D5C2A314F7364BD2711372B6F2C58FA6F39981572E5CA68624D291F8C" },
   { name = "filepath", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "B06A9AF0BF10E51401D64B98E4B627F1D2E48C154967DA7AF4D0914780A6D40A" },
   { name = "gleam_crypto", version = "1.5.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_crypto", source = "hex", outer_checksum = "50774BAFFF1144E7872814C566C5D653D83A3EBF23ACC3156B757A1B6819086E" },
+  { name = "gleam_erlang", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "F91CE62A2D011FA13341F3723DB7DB118541AAA5FE7311BD2716D018F01EF9E3" },
+  { name = "gleam_otp", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "7020E652D18F9ABAC9C877270B14160519FA0856EE80126231C505D719AD68DA" },
   { name = "gleam_regexp", version = "1.1.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_regexp", source = "hex", outer_checksum = "9C215C6CA84A5B35BB934A9B61A9A306EC743153BE2B0425A0D032E477B062A9" },
   { name = "gleam_stdlib", version = "0.60.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "621D600BB134BC239CB2537630899817B1A42E60A1D46C5E9F3FAE39F88C800B" },
   { name = "gleam_time", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_time", source = "hex", outer_checksum = "D71F1AFF7FEB534FF55E5DC58E534E9201BA75A444619788A2E4DEA4EBD87D16" },
@@ -15,9 +18,9 @@ packages = [
   { name = "globlin_fs", version = "2.0.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib", "globlin", "simplifile"], otp_app = "globlin_fs", source = "hex", outer_checksum = "2A84CE81FD7958B967EF39CC234AFB64DAB20169D0EF9B9C3943CD3C5B561182" },
   { name = "gtempo", version = "7.2.2", build_tools = ["gleam"], requirements = ["gleam_regexp", "gleam_stdlib", "gleam_time"], otp_app = "gtempo", source = "hex", outer_checksum = "51AACF841C5F936455973BAF7C03F1EEBF86EC0F0F8D9EBEE126CB02968D50AC" },
   { name = "opentelemetry_api", version = "1.4.0", build_tools = ["rebar3", "mix"], requirements = [], otp_app = "opentelemetry_api", source = "hex", outer_checksum = "3DFBBFAA2C2ED3121C5C483162836C4F9027DEF469C41578AF5EF32589FCFC58" },
-  { name = "pg_types", version = "0.4.0", build_tools = ["rebar3"], requirements = [], otp_app = "pg_types", source = "hex", outer_checksum = "B02EFA785CAECECF9702C681C80A9CA12A39F9161A846CE17B01FB20AEEED7EB" },
-  { name = "pgo", version = "0.14.0", build_tools = ["rebar3"], requirements = ["backoff", "opentelemetry_api", "pg_types"], otp_app = "pgo", source = "hex", outer_checksum = "71016C22599936E042DC0012EE4589D24C71427D266292F775EBF201D97DF9C9" },
-  { name = "pog", version = "3.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "pgo"], otp_app = "pog", source = "hex", outer_checksum = "63152DADEBAE3150C81E9612909974C3C38F3E35B41F252798069A2FD117308E" },
+  { name = "pg_types", version = "0.5.0", build_tools = ["rebar3"], requirements = [], otp_app = "pg_types", source = "hex", outer_checksum = "A3023B464AA960BC1628635081E30CCA4F676F2D4C23CCD6179C1C11C9B4A642" },
+  { name = "pgo", version = "0.15.0", build_tools = ["rebar3"], requirements = ["backoff", "opentelemetry_api", "pg_types"], otp_app = "pgo", source = "hex", outer_checksum = "4B883D751B8D4247F4D8A6FBAE58EDB6FA9DBC183371299BF84975EE36406388" },
+  { name = "pog", version = "4.0.0", build_tools = ["gleam"], requirements = ["exception", "gleam_erlang", "gleam_otp", "gleam_stdlib", "gleam_time", "pgo"], otp_app = "pog", source = "hex", outer_checksum = "E495AAD2C4FD0BB3A92C505682705FA2460053B2D3ABC6F9024C3FED6868417D" },
   { name = "shellout", version = "1.7.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "shellout", source = "hex", outer_checksum = "1BDC03438FEB97A6AF3E396F4ABEB32BECF20DF2452EC9A8C0ACEB7BDDF70B14" },
   { name = "simplifile", version = "2.2.1", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "C88E0EE2D509F6D86EB55161D631657675AA7684DAB83822F7E59EB93D9A60E3" },
 ]
@@ -26,11 +29,13 @@ packages = [
 argv = { version = ">= 1.0.2 and < 2.0.0" }
 envoy = { version = ">= 1.0.2 and < 2.0.0" }
 gleam_crypto = { version = ">= 1.5.1 and < 2.0.0" }
+gleam_erlang = { version = ">= 1.2.0 and < 2.0.0" }
 gleam_stdlib = { version = ">= 0.60.0 and < 1.0.0" }
+gleam_time = { version = ">= 1.2.0 and < 2.0.0" }
 gleeunit = { version = ">= 1.6.0 and < 2.0.0" }
 globlin = { version = ">= 2.0.3 and < 3.0.0" }
 globlin_fs = { version = ">= 2.0.0 and < 3.0.0" }
 gtempo = { version = ">= 7.2.2 and < 8.0.0" }
-pog = { version = ">= 3.1.0 and < 4.0.0" }
+pog = { version = ">= 4.0.0 and < 5.0.0" }
 shellout = { version = ">= 1.7.0 and < 2.0.0" }
 simplifile = { version = ">= 2.2.1 and < 3.0.0" }

--- a/manifest.toml
+++ b/manifest.toml
@@ -6,14 +6,14 @@ packages = [
   { name = "backoff", version = "1.1.6", build_tools = ["rebar3"], requirements = [], otp_app = "backoff", source = "hex", outer_checksum = "CF0CFFF8995FB20562F822E5CC47D8CCF664C5ECDC26A684CBE85C225F9D7C39" },
   { name = "envoy", version = "1.0.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "envoy", source = "hex", outer_checksum = "95FD059345AA982E89A0B6E2A3BF1CF43E17A7048DCD85B5B65D3B9E4E39D359" },
   { name = "filepath", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "B06A9AF0BF10E51401D64B98E4B627F1D2E48C154967DA7AF4D0914780A6D40A" },
-  { name = "gleam_crypto", version = "1.5.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_crypto", source = "hex", outer_checksum = "917BC8B87DBD584830E3B389CBCAB140FFE7CB27866D27C6D0FB87A9ECF35602" },
+  { name = "gleam_crypto", version = "1.5.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_crypto", source = "hex", outer_checksum = "50774BAFFF1144E7872814C566C5D653D83A3EBF23ACC3156B757A1B6819086E" },
   { name = "gleam_regexp", version = "1.1.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_regexp", source = "hex", outer_checksum = "9C215C6CA84A5B35BB934A9B61A9A306EC743153BE2B0425A0D032E477B062A9" },
   { name = "gleam_stdlib", version = "0.60.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "621D600BB134BC239CB2537630899817B1A42E60A1D46C5E9F3FAE39F88C800B" },
   { name = "gleam_time", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_time", source = "hex", outer_checksum = "D71F1AFF7FEB534FF55E5DC58E534E9201BA75A444619788A2E4DEA4EBD87D16" },
-  { name = "gleeunit", version = "1.5.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "D33B7736CF0766ED3065F64A1EBB351E72B2E8DE39BAFC8ADA0E35E92A6A934F" },
+  { name = "gleeunit", version = "1.6.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "63022D81C12C17B7F1A60E029964E830A4CBD846BBC6740004FC1F1031AE0326" },
   { name = "globlin", version = "2.0.3", build_tools = ["gleam"], requirements = ["gleam_regexp", "gleam_stdlib"], otp_app = "globlin", source = "hex", outer_checksum = "923BC16814DF95C4BB28111C266F0B873499480E6E125D5A16DBDF732E62CEB4" },
   { name = "globlin_fs", version = "2.0.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib", "globlin", "simplifile"], otp_app = "globlin_fs", source = "hex", outer_checksum = "2A84CE81FD7958B967EF39CC234AFB64DAB20169D0EF9B9C3943CD3C5B561182" },
-  { name = "gtempo", version = "7.2.1", build_tools = ["gleam"], requirements = ["gleam_regexp", "gleam_stdlib", "gleam_time"], otp_app = "gtempo", source = "hex", outer_checksum = "E9CA4C4FAFCDF5AF34FD8307A0B45FF9593B9AD28953E0445D8FFF923001EF45" },
+  { name = "gtempo", version = "7.2.2", build_tools = ["gleam"], requirements = ["gleam_regexp", "gleam_stdlib", "gleam_time"], otp_app = "gtempo", source = "hex", outer_checksum = "51AACF841C5F936455973BAF7C03F1EEBF86EC0F0F8D9EBEE126CB02968D50AC" },
   { name = "opentelemetry_api", version = "1.4.0", build_tools = ["rebar3", "mix"], requirements = [], otp_app = "opentelemetry_api", source = "hex", outer_checksum = "3DFBBFAA2C2ED3121C5C483162836C4F9027DEF469C41578AF5EF32589FCFC58" },
   { name = "pg_types", version = "0.4.0", build_tools = ["rebar3"], requirements = [], otp_app = "pg_types", source = "hex", outer_checksum = "B02EFA785CAECECF9702C681C80A9CA12A39F9161A846CE17B01FB20AEEED7EB" },
   { name = "pgo", version = "0.14.0", build_tools = ["rebar3"], requirements = ["backoff", "opentelemetry_api", "pg_types"], otp_app = "pgo", source = "hex", outer_checksum = "71016C22599936E042DC0012EE4589D24C71427D266292F775EBF201D97DF9C9" },
@@ -25,12 +25,12 @@ packages = [
 [requirements]
 argv = { version = ">= 1.0.2 and < 2.0.0" }
 envoy = { version = ">= 1.0.2 and < 2.0.0" }
-gleam_crypto = { version = ">= 1.5.0 and < 2.0.0" }
-gleam_stdlib = { version = ">= 0.60.0 and < 2.0.0" }
-gleeunit = { version = ">= 1.0.0 and < 2.0.0" }
-globlin = { version = ">= 2.0.2 and < 3.0.0" }
+gleam_crypto = { version = ">= 1.5.1 and < 2.0.0" }
+gleam_stdlib = { version = ">= 0.60.0 and < 1.0.0" }
+gleeunit = { version = ">= 1.6.0 and < 2.0.0" }
+globlin = { version = ">= 2.0.3 and < 3.0.0" }
 globlin_fs = { version = ">= 2.0.0 and < 3.0.0" }
-gtempo = { version = ">= 7.2.0" }
+gtempo = { version = ">= 7.2.2 and < 8.0.0" }
 pog = { version = ">= 3.1.0 and < 4.0.0" }
-shellout = { version = ">= 1.6.0 and < 2.0.0" }
-simplifile = { version = ">= 2.2.0 and < 3.0.0" }
+shellout = { version = ">= 1.7.0 and < 2.0.0" }
+simplifile = { version = ">= 2.2.1 and < 3.0.0" }

--- a/src/cigogne.gleam
+++ b/src/cigogne.gleam
@@ -113,7 +113,10 @@ pub fn create_migration_engine(
       use url <- result.try(database.get_url())
       create_engine_from_url(url)
     }
-    PogConfig(conf) -> create_engine_from_conn(conf |> pog.connect)
+    PogConfig(conf) -> {
+      let assert Ok(actor) = conf |> pog.start()
+      create_engine_from_conn(actor.data)
+    }
     UrlConfig(url) -> create_engine_from_url(url)
   }
 }

--- a/src/cigogne/internal/database.gleam
+++ b/src/cigogne/internal/database.gleam
@@ -1,6 +1,7 @@
 import cigogne/internal/utils
 import cigogne/types
 import envoy
+import gleam/erlang/process
 import gleam/result
 import pog
 import shellout
@@ -12,11 +13,15 @@ pub fn get_url() -> Result(String, types.MigrateError) {
 
 pub fn connect(url: String) -> Result(pog.Connection, types.MigrateError) {
   use config <- result.try(get_config(url))
-  config |> pog.connect |> Ok
+
+  let assert Ok(actor) = pog.start(config)
+
+  actor.data |> Ok
 }
 
 fn get_config(url: String) -> Result(pog.Config, types.MigrateError) {
-  pog.url_config(url)
+  let db_name = process.new_name("test")
+  pog.url_config(db_name, url)
   |> result.replace_error(types.UrlError(url))
 }
 

--- a/src/cigogne/internal/utils.gleam
+++ b/src/cigogne/internal/utils.gleam
@@ -5,6 +5,8 @@ import gleam/int
 import gleam/list
 import gleam/result
 import gleam/string
+import gleam/time/calendar
+import gleam/time/timestamp
 import pog
 import tempo
 import tempo/date
@@ -43,7 +45,7 @@ pub fn describe_query_error(error: pog.QueryError) -> String {
   }
 }
 
-pub fn describe_transaction_error(error: pog.TransactionError) -> String {
+pub fn describe_transaction_error(error: pog.TransactionError(_)) -> String {
   case error {
     pog.TransactionQueryError(suberror) -> describe_query_error(suberror)
     pog.TransactionRolledBack(message) ->
@@ -61,37 +63,45 @@ pub fn describe_decode_error(error: decode.DecodeError) -> String {
   <> "]"
 }
 
-pub fn tempo_to_pog_timestamp(from: tempo.NaiveDateTime) -> pog.Timestamp {
-  let as_tuple = from |> naive_datetime.to_tuple
+pub fn tempo_to_pog_timestamp(from: tempo.NaiveDateTime) -> timestamp.Timestamp {
+  let #(#(year, month, day), #(hour, minutes, seconds)) =
+    from |> naive_datetime.to_tuple
 
-  pog.Timestamp(
-    pog.Date(as_tuple.0.0, as_tuple.0.1, as_tuple.0.2),
-    pog.Time(as_tuple.1.0, as_tuple.1.1, as_tuple.1.2, 0),
-  )
+  let assert Ok(month) = calendar.month_from_int(month)
+
+  let date = calendar.Date(year, month, day)
+  let time = calendar.TimeOfDay(hour, minutes, seconds, 0)
+
+  timestamp.from_calendar(date, time, calendar.utc_offset)
 }
 
 pub fn pog_to_tempo_timestamp(
-  from: pog.Timestamp,
+  from: timestamp.Timestamp,
 ) -> Result(tempo.NaiveDateTime, Nil) {
-  use date <- result.try(pog_to_tempo_date(from.date))
-  use time <- result.try(pog_to_tempo_time(from.time))
+  let #(date, time_of_day) = from |> timestamp.to_calendar(calendar.utc_offset)
+
+  use date <- result.try(pog_to_tempo_date(date))
+  use time <- result.try(pog_to_tempo_time(time_of_day))
   Ok(naive_datetime.new(date, time))
 }
 
-fn pog_to_tempo_date(from: pog.Date) -> Result(tempo.Date, Nil) {
-  date.new(from.year, from.month, from.day) |> result.replace_error(Nil)
+fn pog_to_tempo_date(from: calendar.Date) -> Result(tempo.Date, Nil) {
+  date.new(from.year, from.month |> calendar.month_to_int(), from.day)
+  |> result.replace_error(Nil)
 }
 
-fn pog_to_tempo_time(from: pog.Time) -> Result(tempo.Time, Nil) {
+fn pog_to_tempo_time(from: calendar.TimeOfDay) -> Result(tempo.Time, Nil) {
   time.new(from.hours, from.minutes, from.seconds) |> result.replace_error(Nil)
 }
 
-pub fn pog_timestamp_to_string(value: pog.Timestamp) -> String {
-  [value.date.year, value.date.month, value.date.day]
+pub fn pog_timestamp_to_string(value: timestamp.Timestamp) -> String {
+  let #(date, time_of_day) = value |> timestamp.to_calendar(calendar.utc_offset)
+
+  [date.year, date.month |> calendar.month_to_int(), date.day]
   |> list.map(int.to_string)
   |> string.join("-")
   <> " "
-  <> [value.time.hours, value.time.minutes, value.time.seconds]
+  <> [time_of_day.hours, time_of_day.minutes, time_of_day.seconds]
   |> list.map(fn(v: Int) {
     case v {
       v if v < 10 -> "0" <> int.to_string(v)

--- a/src/cigogne/types.gleam
+++ b/src/cigogne/types.gleam
@@ -15,7 +15,7 @@ pub type MigrateError {
   FileNameError(path: String)
   CompoundError(errors: List(MigrateError))
   ContentError(path: String, error: String)
-  PGOTransactionError(error: pog.TransactionError)
+  PGOTransactionError(error: pog.TransactionError(String))
   PGOQueryError(error: pog.QueryError)
   NoResultError
   SchemaQueryError(error: String)

--- a/test/cigogne/internal/utils_test.gleam
+++ b/test/cigogne/internal/utils_test.gleam
@@ -1,7 +1,8 @@
 import cigogne/internal/utils
 import gleam/string
+import gleam/time/calendar
+import gleam/time/timestamp
 import gleeunit/should
-import pog
 import tempo/naive_datetime
 
 pub fn tempo_epoch_test() {
@@ -13,18 +14,30 @@ pub fn tempo_epoch_test() {
 pub fn tempo_to_pog_test() {
   naive_datetime.literal("2004-10-15T04:25:33")
   |> utils.tempo_to_pog_timestamp
-  |> should.equal(pog.Timestamp(pog.Date(2004, 10, 15), pog.Time(04, 25, 33, 0)))
+  |> should.equal(timestamp.from_calendar(
+    calendar.Date(2004, calendar.October, 15),
+    calendar.TimeOfDay(04, 25, 33, 0),
+    calendar.utc_offset,
+  ))
 }
 
 pub fn pog_to_tempo_test() {
-  pog.Timestamp(pog.Date(2410, 12, 24), pog.Time(16, 42, 0, 0))
+  timestamp.from_calendar(
+    calendar.Date(2410, calendar.December, 24),
+    calendar.TimeOfDay(16, 42, 0, 0),
+    calendar.utc_offset,
+  )
   |> utils.pog_to_tempo_timestamp
   |> should.be_ok
   |> should.equal(naive_datetime.literal("2410-12-24T16:42:00"))
 }
 
 pub fn pog_to_string_test() {
-  pog.Timestamp(pog.Date(2410, 12, 24), pog.Time(16, 42, 0, 0))
+  timestamp.from_calendar(
+    calendar.Date(2410, calendar.December, 24),
+    calendar.TimeOfDay(16, 42, 0, 0),
+    calendar.utc_offset,
+  )
   |> utils.pog_timestamp_to_string
   |> should.equal("2410-12-24 16:42:00")
 }


### PR DESCRIPTION
Hello. I've upgraded minor dependencies as well as pog to v4, which had some breaking changes. It now starts a single actor to run the migrations. It also uses gleam_time instead of its own datetime representation.

A follow up PR could be to refactor cicogne to use gleam_time instead of gtempo maybe