### PR TITLE
Return non-zero exit status on CLI failures

### DIFF
--- a/src/cigogne.gleam
+++ b/src/cigogne.gleam
@@ -78,14 +78,14 @@ pub fn main() -> Nil {
   let assert Ok(cigogne_config) = config.get(application_name)
   let outcome =
     cli.get_action(application_name, args)
-    |> result.replace_error(UnmatchedCommandError)
+    |> result.map_error(fn(_) { UnmatchedCommandError })
     |> result.try(run_command(_, cigogne_config))
 
   case outcome {
     Ok(_) -> Nil
     Error(UnmatchedCommandError) -> {
       // the CLI library already prints a helpful message.
-      halt(1)
+      halt(2)
     }
     Error(ExecutionError(error)) -> {
       print_error(error)


### PR DESCRIPTION
Hey!
Tried to integrate this into a tooling pipeline and noticed the CLI wasn't returning a proper signal back upon failure.
Noticed there's also a nice interface to this library so planning to go forward with my own script for now, but thought I'd flag this in case you wanted to address it!